### PR TITLE
multiple CRs managing the same configmap

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -17,6 +17,8 @@
 package common
 
 import (
+	"sort"
+
 	gset "github.com/deckarep/golang-set"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -46,6 +48,20 @@ func GetListDifference(slice1 []string, slice2 []string) []string {
 		diff = append(diff, s.(string))
 	}
 	return diff
+}
+
+func CheckListDifference(slice1 []string, slice2 []string) bool {
+	if len(slice1) != len(slice2) {
+		return true
+	}
+	sort.Strings(slice1)
+	sort.Strings(slice2)
+	for i, v := range slice1 {
+		if v != slice2[i] {
+			return true
+		}
+	}
+	return false
 }
 
 func GetOwnerReferenceUIDs(ownerRefs []metav1.OwnerReference) []types.UID {

--- a/controllers/constant/constants.go
+++ b/controllers/constant/constants.go
@@ -22,4 +22,6 @@ const (
 	NamespaceScopeConfigmapName          = "namespace-scope"
 	NamespaceScopeFinalizer              = "finalizer.nss.operator.ibm.com"
 	NamespaceScopeLabel                  = "managedby-namespace-scope"
+	DefaultRestartLabelsKey              = "intent"
+	DefaultRestartLabelsValue            = "projected"
 )

--- a/main.go
+++ b/main.go
@@ -61,8 +61,8 @@ func main() {
 
 	gvkLabelMap := map[schema.GroupVersionKind]cache.Selector{
 		corev1.SchemeGroupVersion.WithKind("ConfigMap"):   {LabelSelector: "managedby-namespace-scope"},
-		rbacv1.SchemeGroupVersion.WithKind("Role"):        {LabelSelector: "projectedfrom"},
-		rbacv1.SchemeGroupVersion.WithKind("RoleBinding"): {LabelSelector: "projectedfrom"},
+		rbacv1.SchemeGroupVersion.WithKind("Role"):        {LabelSelector: "namespace-scope-configmap"},
+		rbacv1.SchemeGroupVersion.WithKind("RoleBinding"): {LabelSelector: "namespace-scope-configmap"},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{


### PR DESCRIPTION
1. Set default restartLabels
2. Update NSS Operator logic: merge all the CRs’ namespaces into the configmap, if they set the same namespace.
3. Add `setDefaults`  for instance during the deletion.
4. role/rolebinding name: namespacescope-managed-role-from-NS-CMNAME