### PR TITLE
switch 1.1.0 to v3 channel

### DIFF
--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -139,5 +139,4 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-namespace-scope-operator-restricted.v1.0.1
   version: 1.1.0

--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -24,6 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     containerImage: quay.io/opencloudio/ibm-namespace-scope-operator:latest
     createdAt: "2020-11-12T17:36:42Z"
+    olm.skipRange: '<1.1.0'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-namespace-scope-operator

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -139,5 +139,4 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-namespace-scope-operator.v1.0.1
   version: 1.1.0

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -24,6 +24,7 @@ metadata:
     capabilities: Seamless Upgrades
     containerImage: quay.io/opencloudio/ibm-namespace-scope-operator:latest
     createdAt: "2020-11-12T17:36:42Z"
+    olm.skipRange: '<1.1.0'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-namespace-scope-operator


### PR DESCRIPTION
1. Remove the `replace` section as it is the origin of v3 channel.

2. add `olm.skipRange: '<1.1.0'` as it supports upgrading from the version smaller than `1.1.0`