### PR TITLE
Grant escalate and bind permission to create role and rolebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,20 @@ When the `NamespaceScope` CR is created/updated, it will:
       resources:
       - '*'
       verbs:
-      - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - rbac.authorization.k8s.io
+      resources:
+      - roles
+      verbs:
+      - escalate
+      - bind
     ---
     kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1

--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -123,6 +123,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - escalate
+          - bind
         serviceAccountName: ibm-namespace-scope-operator
     strategy: deployment
   installModes:

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -54,7 +54,20 @@ spec:
           resources:
           - '*'
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - escalate
+          - bind
         serviceAccountName: ibm-namespace-scope-operator
       deployments:
       - name: ibm-namespace-scope-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,4 +8,17 @@ rules:
     resources:
       - "*"
     verbs:
-      - "*"
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - escalate
+      - bind

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,4 +10,17 @@ rules:
   resources:
   - "*"
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - escalate
+  - bind

--- a/scripts/authorize-namespace.sh
+++ b/scripts/authorize-namespace.sh
@@ -141,7 +141,20 @@ rules:
   resources:
   - "*"
   verbs:
-  - "*"
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - escalate
+  - bind
 EOF
 
 #


### PR DESCRIPTION
Grant escalate and bind permission to role to make sure NamespaceScope operator can create any roles and create rolebinding for it.