### PR TITLE
feat: make namespace scope operator being able to watch multiple namespace

### DIFF
--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -47,6 +47,33 @@ spec:
     mediatype: image/png
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          - pods
+          verbs:
+          - get
+          - list
+        - verbs:
+          - get
+          - list
+          - watch
+          apiGroups:
+          - operator.ibm.com
+          resources:
+          - namespacescopes
+        serviceAccountName: ibm-namespace-scope-operator
       deployments:
       - name: ibm-namespace-scope-operator
         spec:

--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -65,14 +65,14 @@ spec:
           verbs:
           - get
           - list
-        - verbs:
-          - get
-          - list
-          - watch
-          apiGroups:
+        - apiGroups:
           - operator.ibm.com
           resources:
           - namespacescopes
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: ibm-namespace-scope-operator
       deployments:
       - name: ibm-namespace-scope-operator

--- a/config/crd/bases/operator.ibm.com_namespacescopes.yaml
+++ b/config/crd/bases/operator.ibm.com_namespacescopes.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: namespacescopes.operator.ibm.com
 spec:
@@ -17,73 +17,59 @@ spec:
     - nss
     singular: namespacescope
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: NamespaceScope is the Schema for the namespacescopes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: NamespaceScopeSpec defines the desired state of NamespaceScope
-          properties:
-            configmapName:
-              description: ConfigMap name that will contain the list of namespaces
-                to be watched
-              type: string
-            manualManagement:
-              description: Set the following to true to manaually manage permissions
-                for the NamespaceScope operator to extend control over other namespaces
-                The operator may fail when trying to extend permissions to other namespaces,
-                but the cluster administrator can correct this using the authorize-namespace
-                command.
-              type: boolean
-            namespaceMembers:
-              description: Namespaces that are part of this scope
-              items:
-                type: string
-              type: array
-            restartLabels:
-              additionalProperties:
-                type: string
-              description: Restart pods with the following labels when the namspace
-                list changes
-              type: object
-            serviceAccountMembers:
-              description: ServiceAccountMembers are extra service accounts will be
-                bond the roles from other namespaces
-              items:
-                type: string
-              type: array
-          type: object
-        status:
-          description: NamespaceScopeStatus defines the observed state of NamespaceScope
-          properties:
-            validatedMembers:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              items:
-                type: string
-              type: array
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NamespaceScope is the Schema for the namespacescopes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NamespaceScopeSpec defines the desired state of NamespaceScope
+            properties:
+              configmapName:
+                description: ConfigMap name that will contain the list of namespaces to be watched
+                type: string
+              manualManagement:
+                description: Set the following to true to manaually manage permissions for the NamespaceScope operator to extend control over other namespaces The operator may fail when trying to extend permissions to other namespaces, but the cluster administrator can correct this using the authorize-namespace command.
+                type: boolean
+              namespaceMembers:
+                description: Namespaces that are part of this scope
+                items:
+                  type: string
+                type: array
+              restartLabels:
+                additionalProperties:
+                  type: string
+                description: Restart pods with the following labels when the namspace list changes
+                type: object
+              serviceAccountMembers:
+                description: ServiceAccountMembers are extra service accounts will be bond the roles from other namespaces
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: NamespaceScopeStatus defines the observed state of NamespaceScope
+            properties:
+              validatedMembers:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -231,14 +231,16 @@ func (r *NamespaceScopeReconciler) PushRbacToNamespace(instance *operatorv1.Name
 	}
 
 	for _, toNs := range instance.Status.ValidatedMembers {
-		if toNs == operatorNs {
-			continue
+		if toNs != operatorNs {
+			if err := r.generateRBACForNSS(instance, fromNs, toNs); err != nil {
+				return err
+			}
 		}
-		if err := r.generateRBACForNSS(instance, fromNs, toNs); err != nil {
-			return err
-		}
-		if err := r.generateRBACToNamespace(instance, saNames, fromNs, toNs); err != nil {
-			return err
+
+		if toNs != instance.Namespace {
+			if err := r.generateRBACToNamespace(instance, saNames, fromNs, toNs); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -269,14 +271,8 @@ func (r *NamespaceScopeReconciler) DeleteRbacFromUnmanagedNamespace(instance *op
 		"namespace-scope-configmap": instance.Namespace + "-" + instance.Spec.ConfigmapName,
 	}
 
-	operatorNs, err := util.GetOperatorNamespace()
-	if err != nil {
-		klog.Error("get operator namespace failed: ", err)
-		return err
-	}
-
 	for _, toNs := range unmanagedNss {
-		if toNs == operatorNs {
+		if toNs == instance.Namespace {
 			continue
 		}
 
@@ -304,12 +300,6 @@ func (r *NamespaceScopeReconciler) DeleteAllRbac(instance *operatorv1.NamespaceS
 		"namespace-scope-configmap": instance.Namespace + "-" + instance.Spec.ConfigmapName,
 	}
 
-	operatorNs, err := util.GetOperatorNamespace()
-	if err != nil {
-		klog.Error("get operator namespace failed: ", err)
-		return err
-	}
-
 	usingMembers, err := r.getAllValidatedNamespaceMembers(instance)
 	if err != nil {
 		return err
@@ -317,7 +307,7 @@ func (r *NamespaceScopeReconciler) DeleteAllRbac(instance *operatorv1.NamespaceS
 	deletedMembers := util.GetListDifference(instance.Spec.NamespaceMembers, usingMembers)
 
 	for _, toNs := range deletedMembers {
-		if toNs == operatorNs {
+		if toNs == instance.Namespace {
 			continue
 		}
 		if err := r.DeleteRoleBinding(labels, toNs); err != nil {
@@ -700,13 +690,8 @@ func (r *NamespaceScopeReconciler) checkNamespaceAdminAuth(namespace string) boo
 
 func (r *NamespaceScopeReconciler) getValidatedNamespaces(instance *operatorv1.NamespaceScope) ([]string, error) {
 	var validatedNs []string
-	operatorNs, err := util.GetOperatorNamespace()
-	if err != nil {
-		klog.Error("get operator namespace failed: ", err)
-		return validatedNs, err
-	}
 	for _, nsMem := range instance.Spec.NamespaceMembers {
-		if nsMem == operatorNs {
+		if nsMem == instance.Namespace {
 			validatedNs = append(validatedNs, nsMem)
 			continue
 		}

--- a/go.sum
+++ b/go.sum
@@ -318,7 +318,6 @@ golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -347,7 +346,6 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -381,7 +379,6 @@ golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -411,7 +408,6 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ import (
 
 	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 	"github.com/IBM/ibm-namespace-scope-operator/controllers"
-	util "github.com/IBM/ibm-namespace-scope-operator/controllers/common"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -66,16 +65,9 @@ func main() {
 		rbacv1.SchemeGroupVersion.WithKind("RoleBinding"): {LabelSelector: "namespace-scope-configmap"},
 	}
 
-	operatorNs, err := util.GetOperatorNamespace()
-	if err != nil {
-		klog.Error("Failed to get operator namespace: ", err)
-		os.Exit(1)
-	}
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
-		Namespace:          operatorNs,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "6a4a72f9.ibm.com",


### PR DESCRIPTION
This PR enabling the namespace scope operator to watch and manage NSS CR from other namespaces.
Then the service from other namespaces can use namespacescope CR to manage their permission scope.