### PR TITLE
interface conversion error

### DIFF
--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -1054,7 +1054,7 @@ func (r *NamespaceScopeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	err = ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1.NamespaceScope{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Watches(&source.Kind{Type: &olmv1alpha1.Subscription{}}, &handler.EnqueueRequestsFromMapFunc{
+		Watches(&source.Kind{Type: &olmv1alpha1.ClusterServiceVersion{}}, &handler.EnqueueRequestsFromMapFunc{
 			ToRequests: r.csvtoRequest(),
 		}, builder.WithPredicates(predicate.Funcs{
 			DeleteFunc: func(e event.DeleteEvent) bool {


### PR DESCRIPTION
Found error during test
```
I0512 19:29:18.418967       1 namespacescope_controller.go:131] Finished reconciling NamespaceScope: cp4i/common-service
I0512 19:29:18.419044       1 namespacescope_controller.go:109] Reconciling NamespaceScope: cp4i/nss-odlm-scope
I0512 19:29:18.694091       1 namespacescope_controller.go:131] Finished reconciling NamespaceScope: cp4i/nss-odlm-scope
E0512 19:29:20.090725       1 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x1508780), concrete:(*runtime._type)(0x165b0c0), asserted:(*runtime._type)(0x167f840), missingMethod:""} (interface conversion: runtime.Object is *v1alpha1.Subscription, not *v1alpha1.ClusterServiceVersion)
goroutine 445 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x14f8160, 0xc000533080)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/runtime/runtime.go:74 +0xa6
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/runtime/runtime.go:48 +0x89
panic(0x14f8160, 0xc000533080)
	/usr/local/go/src/runtime/panic.go:969 +0x1b9
github.com/IBM/ibm-namespace-scope-operator/controllers.(*NamespaceScopeReconciler).SetupWithManager.func2(0x7fa3e0535598, 0xc00087a380, 0x182ace0, 0xc00087a380, 0x7fa3e0535598, 0xc0002f2380, 0x182ace0, 0xc0002f2380, 0x182ace0)
	/workspace/controllers/namespacescope_controller.go:1065 +0x14c
sigs.k8s.io/controller-runtime/pkg/predicate.Funcs.Update(...)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/predicate/predicate.go:84
sigs.k8s.io/controller-runtime/pkg/source/internal.EventHandler.OnUpdate(0x1858060, 0xc0003cf930, 0x186a380, 0xc000acb760, 0xc0003cfa00, 0x1, 0x1, 0x165b0c0, 0xc00087a380, 0x165b0c0, ...)
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/source/internal/eventsource.go:118 +0x3d6
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/shared_informer.go:742 +0x1c5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000be0760)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006b5f60, 0x18241a0, 0xc0000b8000, 0x14bcc01, 0xc000592120)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156 +0xad
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000be0760, 0x3b9aca00, 0x0, 0x1, 0xc000592120)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc0007fe000)
	/go/pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/shared_informer.go:738 +0x95
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc0001446f0, 0xc00059a020)
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:73 +0x51
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:71 +0x65
panic: interface conversion: runtime.Object is *v1alpha1.Subscription, not *v1alpha1.ClusterServiceVersion [recovered]
	panic: interface conversion: runtime.Object is *v1alpha1.Subscription, not *v1alpha1.ClusterServiceVersion

```