### PR TITLE
hide operator from operatorhub

### DIFF
--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -26,6 +26,7 @@ metadata:
     createdAt: "2020-11-12T17:36:42Z"
     olm.skipRange: '<1.2.0'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
+    operators.operatorframework.io/operator-type: 'non-standalone'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-namespace-scope-operator
     support: IBM

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -26,6 +26,7 @@ metadata:
     createdAt: "2020-11-12T17:36:42Z"
     olm.skipRange: '<1.2.0'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
+    operators.operatorframework.io/operator-type: 'non-standalone'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-namespace-scope-operator
     support: IBM


### PR DESCRIPTION
Add the non-standalone annotation to the ClusterServiceVersion to hide the operator from the OperatorHub page in the OpenShift web console.