### PR TITLE
Revert "adopt multiNamespace Installation mode"

### DIFF
--- a/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/bundle-restricted/manifests/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -94,10 +94,6 @@ spec:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: icr.io/cpopen/ibm-namespace-scope-operator:latest
                 imagePullPolicy: Always
                 name: ibm-namespace-scope-operator
@@ -140,7 +136,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -110,10 +110,6 @@ spec:
                     fieldRef:
                       apiVersion: v1
                       fieldPath: metadata.namespace
-                - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: icr.io/cpopen/ibm-namespace-scope-operator:latest
                 imagePullPolicy: Always
                 name: ibm-namespace-scope-operator
@@ -140,7 +136,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,10 +55,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        - name: WATCH_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.annotations['olm.targetNamespaces']
         resources:
           limits:
             cpu: 500m

--- a/config/manifests/bases/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-namespace-scope-operator-restricted.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ spec:
     type: OwnNamespace
   - supported: true
     type: SingleNamespace
-  - supported: true
+  - supported: false
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -129,16 +129,3 @@ func GetOperatorNamespace() (string, error) {
 	klog.V(1).Info("Found namespace", "Namespace", ns)
 	return ns, nil
 }
-
-// GetWatchNamespace returns the Namespace of the operator
-func GetWatchNamespace() string {
-	ns, found := os.LookupEnv("WATCH_NAMESPACE")
-	if !found {
-		ns, err := GetOperatorNamespace()
-		if err != nil {
-			return ""
-		}
-		return ns
-	}
-	return ns
-}

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -251,8 +251,14 @@ func (r *NamespaceScopeReconciler) PushRbacToNamespace(instance *operatorv1.Name
 		return err
 	}
 
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		klog.Error("get operator namespace failed: ", err)
+		return err
+	}
+
 	for _, toNs := range instance.Status.ValidatedMembers {
-		if toNs == fromNs {
+		if toNs == operatorNs {
 			continue
 		}
 		if err := r.generateRBACForNSS(instance, fromNs, toNs); err != nil {
@@ -268,7 +274,12 @@ func (r *NamespaceScopeReconciler) PushRbacToNamespace(instance *operatorv1.Name
 func (r *NamespaceScopeReconciler) CreateRuntimeRoleToNamespace(instance *operatorv1.NamespaceScope, toNs string, summarizedRules []rbacv1.PolicyRule) error {
 	fromNs := instance.Namespace
 
-	if toNs == fromNs {
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		klog.Error("get operator namespace failed: ", err)
+		return err
+	}
+	if toNs == operatorNs {
 		return nil
 	}
 	if err := r.generateRuntimeRoleForNSS(instance, summarizedRules, fromNs, toNs); err != nil {
@@ -303,8 +314,14 @@ func (r *NamespaceScopeReconciler) DeleteRbacFromUnmanagedNamespace(instance *op
 		"namespace-scope-configmap": instance.Namespace + "-" + instance.Spec.ConfigmapName,
 	}
 
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		klog.Error("get operator namespace failed: ", err)
+		return err
+	}
+
 	for _, toNs := range unmanagedNss {
-		if toNs == instance.Namespace {
+		if toNs == operatorNs {
 			continue
 		}
 
@@ -332,6 +349,12 @@ func (r *NamespaceScopeReconciler) DeleteAllRbac(instance *operatorv1.NamespaceS
 		"namespace-scope-configmap": instance.Namespace + "-" + instance.Spec.ConfigmapName,
 	}
 
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		klog.Error("get operator namespace failed: ", err)
+		return err
+	}
+
 	usingMembers, err := r.getAllValidatedNamespaceMembers(instance)
 	if err != nil {
 		return err
@@ -339,7 +362,7 @@ func (r *NamespaceScopeReconciler) DeleteAllRbac(instance *operatorv1.NamespaceS
 	deletedMembers := util.GetListDifference(instance.Spec.NamespaceMembers, usingMembers)
 
 	for _, toNs := range deletedMembers {
-		if toNs == instance.Namespace {
+		if toNs == operatorNs {
 			continue
 		}
 		if err := r.DeleteRoleBinding(labels, toNs); err != nil {
@@ -958,8 +981,13 @@ func rulesFilter(orgRule []rbacv1.PolicyRule) []rbacv1.PolicyRule {
 
 func (r *NamespaceScopeReconciler) getValidatedNamespaces(instance *operatorv1.NamespaceScope) ([]string, error) {
 	var validatedNs []string
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		klog.Error("get operator namespace failed: ", err)
+		return validatedNs, err
+	}
 	for _, nsMem := range instance.Spec.NamespaceMembers {
-		if nsMem == instance.Namespace {
+		if nsMem == operatorNs {
 			validatedNs = append(validatedNs, nsMem)
 			continue
 		}


### PR DESCRIPTION
This reverts commit cb1481f38065c6c92795ccc3e2f0ee2ef78fd90c.

Revert this back to the same status as existing LTSR stream for CP4D testing

Signed-off-by: YuChen <yuchen.shen@mail.utoronto.ca>