### PR TITLE
Handle NamespaceScope ENV Variable Patching issue 

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -125,6 +125,6 @@ func GetOperatorNamespace() (string, error) {
 	if len(ns) == 0 {
 		return "", fmt.Errorf("operator namespace is empty")
 	}
-	klog.V(1).Info("Found namespace", "Namespace", ns)
+	klog.V(1).Infof("Found namespace: %s", ns)
 	return ns, nil
 }

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -1083,64 +1083,68 @@ func (r *NamespaceScopeReconciler) CSVReconcile(req ctrl.Request) (ctrl.Result, 
 			continue
 		}
 		patchedCSVList = append(patchedCSVList, packageName.(string))
-		csv := csvList.Items[0]
-		csvOriginal := csv.DeepCopy()
-		if csv.Spec.InstallStrategy.StrategyName != "deployment" {
-			continue
-		}
-		deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
-		for _, deploy := range deploymentSpecs {
-			podTemplate := deploy.Spec.Template
-			// Insert restartlabel into operator pods
-			if podTemplate.Labels == nil {
-				podTemplate.Labels = make(map[string]string)
+
+		for _, csv := range csvList.Items {
+			klog.V(2).Infof("Found CSV %s for packageManifest %s", csv.Name, packageName.(string))
+			csvOriginal := csv.DeepCopy()
+			if csv.Spec.InstallStrategy.StrategyName != "deployment" {
+				continue
 			}
-			for k, v := range instance.Spec.RestartLabels {
-				podTemplate.Labels[k] = v
-			}
-			// Insert WATCH_NAMESPACE into operator pod environment variables
-			for containerIndex, container := range podTemplate.Spec.Containers {
-				var found bool
-				optional := true
-				configmapEnv := corev1.EnvVar{
-					Name: "WATCH_NAMESPACE",
-					ValueFrom: &corev1.EnvVarSource{
-						ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-							Optional: &optional,
-							Key:      "namespaces",
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: configmapName,
+			deploymentSpecs := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
+			for _, deploy := range deploymentSpecs {
+				podTemplate := deploy.Spec.Template
+				// Insert restartlabel into operator pods
+				if podTemplate.Labels == nil {
+					podTemplate.Labels = make(map[string]string)
+				}
+				for k, v := range instance.Spec.RestartLabels {
+					podTemplate.Labels[k] = v
+				}
+				// Insert WATCH_NAMESPACE into operator pod environment variables
+				for containerIndex, container := range podTemplate.Spec.Containers {
+					var found bool
+					optional := true
+					configmapEnv := corev1.EnvVar{
+						Name: "WATCH_NAMESPACE",
+						ValueFrom: &corev1.EnvVarSource{
+							ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+								Optional: &optional,
+								Key:      "namespaces",
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: configmapName,
+								},
 							},
 						},
-					},
-				}
-				for index, env := range container.Env {
-					if env.Name == "WATCH_NAMESPACE" {
-						found = true
-						if env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Key == "namespaces" && env.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name == configmapName {
-							continue
-						}
-						container.Env[index] = configmapEnv
 					}
+					for index, env := range container.Env {
+						if env.Name == "WATCH_NAMESPACE" {
+							found = true
+							if env.ValueFrom.ConfigMapKeyRef != nil && env.ValueFrom.ConfigMapKeyRef.Key == "namespaces" && env.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name == configmapName {
+								klog.V(2).Infof("WATCH_NAMESPACE ENV variable is found in CSV %s, and match the configmap %s, skip it", csv.Name, configmapName)
+								continue
+							}
+							klog.V(2).Infof("WATCH_NAMESPACE ENV variable is found in CSV %s, but not match the configmap %s, replace it", csv.Name, configmapName)
+							container.Env[index] = configmapEnv
+						}
+					}
+					if !found {
+						klog.V(2).Infof("WATCH_NAMESPACE ENV variable is not found in CSV %s, insert it", csv.Name)
+						container.Env = append(container.Env, configmapEnv)
+					}
+					podTemplate.Spec.Containers[containerIndex] = container
 				}
-				if !found {
-					container.Env = append(container.Env, configmapEnv)
-				}
-				podTemplate.Spec.Containers[containerIndex] = container
 			}
-		}
+			if equality.Semantic.DeepEqual(csvOriginal.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs) {
+				klog.V(3).Infof("No updates in the CSV, skip patching the CSV %s ", csv.Name)
+				continue
+			}
 
-		if equality.Semantic.DeepDerivative(csvOriginal.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs) {
-			klog.V(3).Infof("No updates in the CSV, skip patching the CSV %s ", csv.Name)
-			continue
+			if err := r.Client.Patch(ctx, &csv, client.MergeFrom(csvOriginal)); err != nil {
+				klog.Error(err)
+				return ctrl.Result{}, err
+			}
+			klog.V(1).Infof("WATCH_NAMESPACE and restart labels are inserted into CSV %s ", csv.Name)
 		}
-
-		if err := r.Client.Patch(ctx, &csv, client.MergeFrom(csvOriginal)); err != nil {
-			klog.Error(err)
-			return ctrl.Result{}, err
-		}
-		klog.V(1).Infof("WATCH_NAMESPACE and restart labels are inserted into CSV %s ", csv.Name)
-
 	}
 
 	if util.CheckListDifference(instance.Status.ManagedCSVList, managedCSVList) {


### PR DESCRIPTION
This PR is focused on three aspects
1. Use `DeepEqual` to compare original CSV containing nil struct and patched CSV containing `WATCH_NAMESPACE`
2. Patch `WATCH_NAMESPACE` to all CSVs for the given Package Manifest
3. Add more v(2) information logs for debugging purpose

## Replace `DeepDerivative` with `DeepEqual`
### Issue with `DeepDerivative`
Originally we are using `DeepDerivative` to compare the deployment templates before and after updating `WATCH_NAMESPACE` variable.
```
if equality.Semantic.DeepDerivative(csvOriginal.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs) {
	klog.V(3).Infof("No updates in the CSV, skip patching the CSV %s ", csv.Name)
	continue
}
```

However, from the description of `DeepDerivative`, it states that
```
DeepDerivative is similar to DeepEqual except that unset fields are ignored (not compared)
```

It means that if the original CSV does not contain `WATCH_NAMESPACE`(unset field) and patched CSV contains `WATCH_NAMESPACE` ENV variable, then this `WATCH_NAMESPACE` field is ignored by `DeepDerivative`. The if condition always returns `true`, and claim that there is no Update in CSV.


When we are using `DeepDerivative`, we will observe this kind of logs in NSS operator pod
```
I0718 03:44:23.476340       1 namespacescope_controller.go:1131] WATCH_NAMESPACE is not found in CSV ibm-cpd-ws-runtimes.v7.3.0, insert it
I0718 03:44:23.476397       1 namespacescope_controller.go:1138] No updates in the CSV, skip patching the CSV ibm-cpd-ws-runtimes.v7.3.0 
```

### Fix with `DeepEqual`
However, in the description of `DeepEqual`, it states that
```
It will use e's equality functions if it finds types that match.
An empty slice *is* equal to a nil slice for our purposes; same for maps.
```

When we are using `DeepEqual`, we will observe expected logs in NSS operator pod
```
I0718 03:46:22.744474       1 namespacescope_controller.go:1131] WATCH_NAMESPACE is not found in CSV ibm-cpd-ws-runtimes.v7.3.0, insert it
I0718 03:46:22.769520       1 namespacescope_controller.go:1146] WATCH_NAMESPACE and restart labels are inserted into CSV ibm-cpd-ws-runtimes.v7.3.0
```

## Patch `WATCH_NAMESPACE` to all CSVs for the given Package Manifest

### Issue in upgrade with multiple CSVs
When Common Service Operator is upgraded, there is a intermediate stage when we could see two Common Service Operator CSVs in the same namespace. One is from old version, and the other is from new version. Here is an example
![image (4)](https://github.com/IBM/ibm-namespace-scope-operator/assets/29827416/8eeefcbb-0958-42ae-a43f-f6bccdcfe3cf)

However, when NamespaceScope Operator is looking for the CSV for given packagemanifest `ibm-common-service-operator`, it lists all CSVs contains label `operators.coreos.com/ibm-common-service-operator.<namespace>: ''`, but only pick the first CSV in the list to check and update.
```
csv := csvList.Items[0]
```

In this upgrade scenario, NamespaceScope Operator will pick up the Common Service Operator CSV with old version, and it will never update the new CSV for common service operator. As a result, the script is failed to wait NamespaceScope patching new CSV.
```
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (1 left)
[✗] Deleting pod ibm-namespace-scope-operator-7dc9dc5b4b-nff8v in namespace cpfs-operators to trigger NamespaceScope reconciliaiton
pod "ibm-namespace-scope-operator-7dc9dc5b4b-nff8v" deleted
[INFO] Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (6 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (5 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (4 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (3 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (2 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (1 left)
[✘] Timeout after 5 minutes waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
```

Here is also the logs in NamespaceScope Operator, it always check the old CSV (v4.0.1 CS operator), and never update new CSV (v4.1.0 CS operator) when both CSVs exist
```
I0718 05:44:28.660689 1 namespacescope_controller.go:1134] No updates in the CSV, skip patching the CSV ibm-common-service-operator.v4.0.1
```
<img width="1613" alt="Screenshot 2023-07-18 at 1 44 48 AM" src="https://github.com/IBM/ibm-namespace-scope-operator/assets/29827416/b3e81ae3-c6ff-4dc6-90d1-9a42b5077967">

### Solution to patch all CSVs for given PackageManifest
After we patch the new image to update all CSVs (both v4.0.1 and v4.1.0) for given packagemanifest `ibm-common-service-operator`, it helps to solve the issue immediately.
```
for _, csv := range csvList.Items {
	klog.V(2).Infof("Found CSV %s for packageManifest %s", csv.Name, packageName.(string))
}
```
Here is the logs from scripts
```
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (25 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (24 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (23 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (22 left)
[✔] operator ibm-common-service-operator CSV is patched with NamespaceScope ConfigMap
```
Here is the logs from NamespaceScope Operator, it patch two CSVs for Common Service Operator.
```
I0718 05:45:28.585384       1 namespacescope_controller.go:1123] WATCH_NAMESPACE is found in CSV ibm-common-service-operator.v4.0.1, skip patching
I0718 05:45:28.585458       1 namespacescope_controller.go:1138] No updates in the CSV, skip patching the CSV ibm-common-service-operator.v4.0.1 
I0718 05:45:28.585467       1 namespacescope_controller.go:1088] Patching CSV: ibm-common-service-operator.v4.1.0
I0718 05:49:39.246913       1 namespacescope_controller.go:1126] WATCH_NAMESPACE is found in CSV ibm-common-service-operator.v4.1.0, but not match the configmap namespace-scope, replace it
I0718 05:49:39.276324       1 namespacescope_controller.go:1146] WATCH_NAMESPACE and restart labels are inserted into CSV ibm-common-service-operator.v4.1.0
```
