### PR TITLE
Keep basic permissions and remove wildcard* in NSS operator CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CONTROLLER_GEN ?= $(shell which controller-gen)
 KUSTOMIZE ?= $(shell which kustomize)
 YQ_VERSION=3.4.0
 KUSTOMIZE_VERSION=v3.8.7
-OPERATOR_SDK_VERSION=v1.20.0
+OPERATOR_SDK_VERSION=v1.32.0
 
 GOPATH=$(HOME)/go/bin/
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-namespace-scope-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.0
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.0
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-namespace-scope-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.0
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.0
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
 

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
     createdAt: "2020-11-2T15:38:33Z"
     olm.skipRange: '<4.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.24.0
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-namespace-scope-operator
     support: IBM

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -23,11 +23,11 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/ibm-namespace-scope-operator:latest
-    createdAt: "2023-02-26T12:14:20Z"
+    createdAt: "2020-11-2T15:38:33Z"
     olm.skipRange: '<4.2.1'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/ibm-namespace-scope-operator
     support: IBM
   labels:
@@ -75,7 +75,6 @@ spec:
           app.kubernetes.io/instance: ibm-namespace-scope-operator
           app.kubernetes.io/managed-by: ibm-namespace-scope-operator
           app.kubernetes.io/name: ibm-namespace-scope-operator
-          productName: IBM_Cloud_Platform_Common_Services
         name: ibm-namespace-scope-operator
         spec:
           replicas: 1
@@ -93,7 +92,6 @@ spec:
                 app.kubernetes.io/instance: ibm-namespace-scope-operator
                 app.kubernetes.io/managed-by: ibm-namespace-scope-operator
                 app.kubernetes.io/name: ibm-namespace-scope-operator
-                productName: IBM_Cloud_Platform_Common_Services
                 name: ibm-namespace-scope-operator
             spec:
               affinity:
@@ -142,9 +140,10 @@ spec:
       permissions:
       - rules:
         - apiGroups:
-          - '*'
+          - rbac.authorization.k8s.io
           resources:
-          - '*'
+          - rolebindings
+          - roles
           verbs:
           - create
           - delete
@@ -153,7 +152,40 @@ spec:
           - patch
           - update
           - watch
-          - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - namespacescopes
+          - namespacescopes/status
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: ibm-namespace-scope-operator
     strategy: deployment
   installModes:

--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -75,6 +75,7 @@ spec:
           app.kubernetes.io/instance: ibm-namespace-scope-operator
           app.kubernetes.io/managed-by: ibm-namespace-scope-operator
           app.kubernetes.io/name: ibm-namespace-scope-operator
+          productName: IBM_Cloud_Platform_Common_Services
         name: ibm-namespace-scope-operator
         spec:
           replicas: 1
@@ -93,6 +94,7 @@ spec:
                 app.kubernetes.io/managed-by: ibm-namespace-scope-operator
                 app.kubernetes.io/name: ibm-namespace-scope-operator
                 name: ibm-namespace-scope-operator
+                productName: IBM_Cloud_Platform_Common_Services
             spec:
               affinity:
                 nodeAffinity:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-namespace-scope-operator
   operators.operatorframework.io.bundle.channels.v1: v4.0
   operators.operatorframework.io.bundle.channel.default.v1: v4.0
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
 

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-namespace-scope-operator
   operators.operatorframework.io.bundle.channels.v1: v4.0
   operators.operatorframework.io.bundle.channel.default.v1: v4.0
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: "ibm-namespace-scope-operator"
     app.kubernetes.io/managed-by: "ibm-namespace-scope-operator"
     app.kubernetes.io/name: "ibm-namespace-scope-operator"
+    productName: IBM_Cloud_Platform_Common_Services
 spec:
   selector:
     matchLabels:
@@ -24,6 +25,7 @@ spec:
         app.kubernetes.io/instance: ibm-namespace-scope-operator
         app.kubernetes.io/managed-by: "ibm-namespace-scope-operator"
         app.kubernetes.io/name: "ibm-namespace-scope-operator"
+        productName: IBM_Cloud_Platform_Common_Services
       annotations:
         productName: "IBM Cloud Platform Common Services"
         productID: "068a62892a1e4db39641342e592daa25"

--- a/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -6,9 +6,9 @@ metadata:
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/ibm-namespace-scope-operator:latest
     createdAt: "2020-11-2T15:38:33Z"
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/ibm-namespace-scope-operator
     support: IBM
   labels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,11 +3,7 @@ kind: Role
 metadata:
   name: ibm-namespace-scope-operator
 rules:
-  - apiGroups:
-      - "*"
-    resources:
-      - "*"
-    verbs:
+  - verbs:
       - create
       - delete
       - get
@@ -15,7 +11,45 @@ rules:
       - patch
       - update
       - watch
-      - deletecollection
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - pods
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - namespacescopes
+      - namespacescopes/status
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60516
Removing wildcard * and explicitly listing out the basic permissions need by NSS operator in its CSV to finish reconciliation

#### How to evaluate 
1. Install NSS operator in operator namespace and create nss CR
2. Remove wildcard * and apply basic permission list in CSV
3. Copy the permissions listed from NSS operator CSV, and create a Role with those permissions in a tethered namespace.
4. Bind this Role in the tethered namespace with NSS operator's service account in operator namespace
5. Verify if NamespaceScope operator is able to project it own RBAC, and reconciliation is finished. 


