### PR TITLE
Add missing permission for NSS operator

### DIFF
--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/ibm-namespace-scope-operator:latest
-    createdAt: "2020-11-2T15:38:33Z"
+    createdAt: "2023-11-02T00:44:43Z"
     olm.skipRange: '<4.2.1'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
@@ -69,6 +69,13 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
         serviceAccountName: ibm-namespace-scope-operator
       deployments:
       - label:
@@ -154,6 +161,7 @@ spec:
           - patch
           - update
           - watch
+          - deletecollection
         - apiGroups:
           - ""
           resources:
@@ -182,12 +190,35 @@ spec:
           resources:
           - namespacescopes
           - namespacescopes/status
+          - namespacescopes/finalizers
           verbs:
           - get
           - list
           - patch
           - update
           - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - statefulsets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - deletecollection
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
         serviceAccountName: ibm-namespace-scope-operator
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,7 @@ rules:
       - patch
       - update
       - watch
+      - deletecollection
     apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -50,6 +51,29 @@ rules:
     resources:
       - namespacescopes
       - namespacescopes/status
+      - namespacescopes/finalizers
+  - verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+      - create
+    apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -57,16 +81,23 @@ metadata:
   name: ibm-namespace-scope-operator
 rules:
 # manage mutation webhook configuration
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - namespaces

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -949,7 +949,7 @@ func (r *NamespaceScopeReconciler) getValidatedNamespaces(ctx context.Context, i
 		if r.checkGetNSAuth(ctx) {
 			ns := &corev1.Namespace{}
 			key := types.NamespacedName{Name: nsMem}
-			if err := r.Client.Get(ctx, key, ns); err != nil {
+			if err := r.Reader.Get(ctx, key, ns); err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("Namespace %s does not exist and will be ignored", nsMem)
 					continue


### PR DESCRIPTION
- Resolve following errors, this issue could happen on `deployment`, `statefulset` and `daemonset`
  ```
  E1102 00:28:08.507129 1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.1/tools/cache/reflector.go:167: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:cs1:ibm-namespace-scope-operator" cannot list resource "deployments" in API group "apps" in the namespace "cs1"
  ```

- Add cluster permission to [get namespace for `function getValidatedNamespaces()`](https://github.com/IBM/ibm-namespace-scope-operator/blob/ae94063b7be55b2117e08520c3359dc9b9c50b77/controllers/namespacescope_controller.go#L936)