### PR TITLE
add labels for role and rolebinding created by NSS

### DIFF
--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -462,7 +462,10 @@ func (r *NamespaceScopeReconciler) updateRuntimeRoleForNSS(ctx context.Context, 
 
 func (r *NamespaceScopeReconciler) generateRBACToNamespace(ctx context.Context, instance *operatorv1.NamespaceScope, saNames []string, fromNs, toNs string) error {
 	labels := map[string]string{
-		"namespace-scope-configmap": instance.Namespace + "-" + instance.Spec.ConfigmapName,
+		"namespace-scope-configmap":    instance.Namespace + "-" + instance.Spec.ConfigmapName,
+		"app.kubernetes.io/instance":   "namespace-scope",
+		"app.kubernetes.io/managed-by": "ibm-namespace-scope-operator",
+		"app.kubernetes.io/name":       instance.Name,
 	}
 	for _, sa := range saNames {
 		roleList, err := r.GetRolesFromServiceAccount(ctx, sa, fromNs)


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/60971

### How to test
Test image: quay.io/yuchen_shen/nss:label
1. Deploy advanced topologies with NameSpace Scope installed
2. Apply the test image
3. Delete the those roles for  cs-operator, and ODLM
4. Labels added
  ```
  labels:
      app.kubernetes.io/instance: namespace-scope
      app.kubernetes.io/managed-by: ibm-namespace-scope-operator
      app.kubernetes.io/name: common-service
  ```