### PR TITLE
Set instance name as configmap name

### DIFF
--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -465,7 +465,7 @@ func (r *NamespaceScopeReconciler) generateRBACToNamespace(ctx context.Context, 
 		"namespace-scope-configmap":    instance.Namespace + "-" + instance.Spec.ConfigmapName,
 		"app.kubernetes.io/instance":   "namespace-scope",
 		"app.kubernetes.io/managed-by": "ibm-namespace-scope-operator",
-		"app.kubernetes.io/name":       instance.Name,
+		"app.kubernetes.io/name":       instance.Spec.ConfigmapName,
 	}
 	for _, sa := range saNames {
 		roleList, err := r.GetRolesFromServiceAccount(ctx, sa, fromNs)


### PR DESCRIPTION
This fix is ​​to solve the problem that the instance name will be updated back and forth into different NSS CRs' names if there are more than one NSS CRs in this cluster, then set the name as `namespace-scope` ConfigMap's name.