### PR TITLE
Update go module to match major version v4

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -7,7 +7,7 @@ resources:
     domain: ibm.com
     group: operator
     kind: NamespaceScope
-    path: github.com/IBM/ibm-namespace-scope-operator/api/v1
+    path: github.com/IBM/ibm-namespace-scope-operator/v4/api/v1
     version: v1
 version: "3"
 plugins:

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -52,9 +52,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
-	util "github.com/IBM/ibm-namespace-scope-operator/controllers/common"
-	"github.com/IBM/ibm-namespace-scope-operator/controllers/constant"
+	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
+	util "github.com/IBM/ibm-namespace-scope-operator/v4/controllers/common"
+	"github.com/IBM/ibm-namespace-scope-operator/v4/controllers/constant"
 )
 
 //var ctx context.Context

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
+	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/IBM/ibm-namespace-scope-operator
+module github.com/IBM/ibm-namespace-scope-operator/v4
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -33,9 +33,9 @@ import (
 
 	cache "github.com/IBM/controller-filtered-cache/filteredcache"
 
-	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
-	"github.com/IBM/ibm-namespace-scope-operator/controllers"
-	util "github.com/IBM/ibm-namespace-scope-operator/controllers/common"
+	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
+	"github.com/IBM/ibm-namespace-scope-operator/v4/controllers"
+	util "github.com/IBM/ibm-namespace-scope-operator/v4/controllers/common"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
https://go.dev/ref/mod#major-version-suffixes
Starting with major version 2, module paths must have a major version suffix like /v2 that matches the major version. For example, if a module has the path example.com/mod at v1.0.0, it must have the path example.com/mod/v2 at version v2.0.0.