### PR TITLE
label length limitation

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -156,3 +156,12 @@ func GetResourcesDynamically(ctx context.Context, dynamic dynamic.Interface, gro
 
 	return list.Items, nil
 }
+
+func GetFirstNCharacter(str string, n int) string {
+	v := []rune(str)
+	if n >= len(v) {
+		return str
+	}
+	return string(v[:n])
+
+}

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -158,10 +158,9 @@ func GetResourcesDynamically(ctx context.Context, dynamic dynamic.Interface, gro
 }
 
 func GetFirstNCharacter(str string, n int) string {
-	v := []byte(str)
-	if n >= len(v) {
+	if n >= len(str) {
 		return str
 	}
-	return string(v[:n])
+	return string(str[:n])
 
 }

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -161,6 +161,5 @@ func GetFirstNCharacter(str string, n int) string {
 	if n >= len(str) {
 		return str
 	}
-	return string(str[:n])
-
+	return str[:n]
 }

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -158,7 +158,7 @@ func GetResourcesDynamically(ctx context.Context, dynamic dynamic.Interface, gro
 }
 
 func GetFirstNCharacter(str string, n int) string {
-	v := []rune(str)
+	v := []byte(str)
 	if n >= len(v) {
 		return str
 	}

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -1015,9 +1015,11 @@ func (r *NamespaceScopeReconciler) CSVReconcile(ctx context.Context, req ctrl.Re
 	for _, packageName := range candidateSet.ToSlice() {
 		managedCSVList = append(managedCSVList, packageName.(string))
 		csvList := &olmv1alpha1.ClusterServiceVersionList{}
+		labelKey := packageName.(string) + "." + instance.Namespace
+		labelKey = util.GetFirstNCharacter(labelKey, 63)
 		if err := r.Client.List(ctx, csvList, &client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
-				"operators.coreos.com/" + packageName.(string) + "." + instance.Namespace: "",
+				"operators.coreos.com/" + labelKey: "",
 			})}); err != nil {
 			klog.Error(err)
 			return ctrl.Result{}, err


### PR DESCRIPTION
What this PR does / why we need it:
k8s label name length limit to 64 characters, so olm will cut off any label longer than 64 characters
We rely on label to find csv and subscription, so we also need to cut of the label if it is longer than 64 characters.
Which issue(s) this PR fixes:
script enhancement for # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64378