### PR TITLE
fixed incorrect tetheredNamespace reference

### DIFF
--- a/helm/templates/01-operator-deployment.yaml
+++ b/helm/templates/01-operator-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           ]
         capabilities: Seamless Upgrades
         productName: IBM Cloud Platform Common Services
-        containerImage: '{{ .Values.global.imagePullPrefix }}/{{ .Values.imageRegistryNamespaceOperator }}/ibm-namespace-scope-operator:4.2.12'
+        containerImage: {{ .Values.global.imagePullPrefix }}/{{ .Values.imageRegistryNamespaceOperator }}/ibm-namespace-scope-operator:4.2.12
         productMetric: FREE
     spec:
       restartPolicy: Always
@@ -104,7 +104,7 @@ spec:
               type: RuntimeDefault
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: File
-          image: '{{ .Values.global.imagePullPrefix }}/{{ .Values.imageRegistryNamespaceOperator }}/ibm-namespace-scope-operator:4.2.12'
+          image: {{ .Values.global.imagePullPrefix }}/{{ .Values.imageRegistryNamespaceOperator }}/ibm-namespace-scope-operator:4.2.12
       serviceAccount: ibm-namespace-scope-operator
       dnsPolicy: ClusterFirst
   strategy:

--- a/helm/templates/02-nss-cr.yaml
+++ b/helm/templates/02-nss-cr.yaml
@@ -13,7 +13,7 @@ spec:
   namespaceMembers:
     - {{ .Values.global.operatorNamespace }}
     - {{ .Values.global.instanceNamespace }}
-    {{- range $i, $v := $.Values.tenantNamespaces }}
+    {{- range $i, $v := $.Values.tetheredNamespace }}
     - {{ $v }}
     {{- end }}
   restartLabels:


### PR DESCRIPTION
removed apostrophes around image value because CICD automation removes the closing apostrophe, leading to image pull error because the values looks like `'image:digest`