### PR TITLE
Add RELEASE_VERSION into docker build arg for RH certification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ e2e-test: ## Run e2e test
 build-operator-image: $(CONFIG_DOCKER_TARGET) ## Build the operator image.
 	@echo "Building the $(OPERATOR_IMAGE_NAME) docker image for $(LOCAL_ARCH)..."
 	@docker build -t $(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):$(VERSION) \
-	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) \
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 
 ##@ Release


### PR DESCRIPTION
The current build is missing `release` and `version` label.
```
➜  docker image inspect docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/ibm-namespace-scope-operator:4.2.14 | grep "version"
                "io.buildah.version": "1.39.0-dev",
                "org.label-schema.schema-version": "1.0",
                "version": ""
➜  docker image inspect docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/ibm-namespace-scope-operator:4.2.14 | grep "release"
                "release": "",
```