### PR TITLE
skip adding finalizer to CR when helm install

### DIFF
--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -179,6 +179,9 @@ func (r *NamespaceScopeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *NamespaceScopeReconciler) addFinalizer(ctx context.Context, nss *operatorv1.NamespaceScope) error {
+	if nss.Labels["cpfs.helm/install"] == "true" {
+		return nil
+	}
 	controllerutil.AddFinalizer(nss, constant.NamespaceScopeFinalizer)
 	if err := r.Update(ctx, nss); err != nil {
 		klog.Errorf("Failed to update NamespaceScope with finalizer: %v", err)

--- a/helm/templates/02-nss-cr.yaml
+++ b/helm/templates/02-nss-cr.yaml
@@ -2,6 +2,7 @@ apiVersion: operator.ibm.com/v1
 kind: NamespaceScope
 metadata:
   labels:
+    cpfs.helm/install: 'true'
     foundationservices.cloudpak.ibm.com: nss
     component-id: {{ .Chart.Name }}
     {{- with .Values.cpfs.labels }}


### PR DESCRIPTION
to avoid the issue of stuck terminating CR after helm uninstall
to avoid the issue of CR garbage collected after a helm re-install