### PR TITLE
ignore difference in the order of namesapceList

### DIFF
--- a/common/scripts/lint_go.sh
+++ b/common/scripts/lint_go.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=180s
+GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=480s

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -1305,7 +1305,7 @@ func (r *NamespaceScopeReconciler) patchValidatingWebhook(ctx context.Context, w
 		if webhook.NamespaceSelector.MatchExpressions != nil {
 			if webhook.NamespaceSelector.MatchExpressions[0].Values != nil {
 				namespaces := webhook.NamespaceSelector.MatchExpressions[0].Values
-				if util.CheckListDifference(namespaces, nsList) {
+				if !util.CheckListDifference(namespaces, nsList) {
 					klog.V(2).Infof("Namespace selector has been patched, skip patching webhook")
 					skipPatch = true
 				}

--- a/controllers/namespacescope_controller.go
+++ b/controllers/namespacescope_controller.go
@@ -1266,7 +1266,7 @@ func (r *NamespaceScopeReconciler) patchMutatingWebhook(ctx context.Context, web
 		if webhook.NamespaceSelector.MatchExpressions != nil {
 			if webhook.NamespaceSelector.MatchExpressions[0].Values != nil {
 				namespaces := webhook.NamespaceSelector.MatchExpressions[0].Values
-				if reflect.DeepEqual(namespaces, nsList) {
+				if !util.CheckListDifference(namespaces, nsList) {
 					klog.V(2).Infof("Namespace selector has been patched, skip patching webhook")
 					skipPatch = true
 				}
@@ -1305,7 +1305,7 @@ func (r *NamespaceScopeReconciler) patchValidatingWebhook(ctx context.Context, w
 		if webhook.NamespaceSelector.MatchExpressions != nil {
 			if webhook.NamespaceSelector.MatchExpressions[0].Values != nil {
 				namespaces := webhook.NamespaceSelector.MatchExpressions[0].Values
-				if reflect.DeepEqual(namespaces, nsList) {
+				if util.CheckListDifference(namespaces, nsList) {
 					klog.V(2).Infof("Namespace selector has been patched, skip patching webhook")
 					skipPatch = true
 				}


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66657

we shouldn't use [reflect.deepequal](https://github.com/IBM/ibm-namespace-scope-operator/blob/master/controllers/namespacescope_controller.go#L1269) to compare two namespace lists because the order might different. This would cause nss operator reconciling forever and will put high strain on api-server as well