### PR TITLE
Bump Namespace Scope Operator version to 4.2.19

### DIFF
--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    containerImage: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+    containerImage: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
     createdAt: "2025-02-19T00:54:24Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -31,7 +31,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: <4.2.18
+    olm.skipRange: <4.2.19
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -42,7 +42,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-namespace-scope-operator.v4.2.18
+  name: ibm-namespace-scope-operator.v4.2.19
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -131,7 +131,7 @@ spec:
                           fieldRef:
                             apiVersion: v1
                             fieldPath: metadata.namespace
-                    image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+                    image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
                     imagePullPolicy: IfNotPresent
                     name: ibm-namespace-scope-operator
                     resources:
@@ -251,7 +251,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: IBM
-  version: 4.2.18
+  version: 4.2.19
   relatedImages:
-    - image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+    - image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
       name: IBM_NAMESPACE_SCOPE_OPERATOR_IMAGE

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: icr.io/cpopen/ibm-namespace-scope-operator
   newName: icr.io/cpopen/ibm-namespace-scope-operator
-  newTag: 4.2.18
+  newTag: 4.2.19

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
       - command:
         - /namespace-scope-operator-manager
-        image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+        image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
         imagePullPolicy: IfNotPresent
         name: ibm-namespace-scope-operator
         env:

--- a/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
-    containerImage: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+    containerImage: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
     createdAt: "2020-11-2T15:38:33Z"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -13,7 +13,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: <4.2.18
+    olm.skipRange: <4.2.19
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -68,6 +68,6 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.18
+  - image: icr.io/cpopen/ibm-namespace-scope-operator:4.2.19
     name: IBM_NAMESPACE_SCOPE_OPERATOR_IMAGE
   version: 0.0.0

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "4.2.18"
+	Version = "4.2.19"
 )


### PR DESCRIPTION
What this PR does / why we need it:
Update NSS to 4.2.19 for CS 4.6.19