### PR TITLE
CPD-Quality 57014, add default labels to cluster scoped resources

### DIFF
--- a/helm-cluster-scoped/templates/00-crd.yaml
+++ b/helm-cluster-scoped/templates/00-crd.yaml
@@ -7,6 +7,12 @@ metadata:
   name: namespacescopes.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/01-cluster-rbac.yaml
+++ b/helm-cluster-scoped/templates/01-cluster-rbac.yaml
@@ -4,6 +4,12 @@ metadata:
   name: ibm-namespace-scope-operator-{{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
   - verbs:
       - create

--- a/helm-cluster-scoped/values.yaml
+++ b/helm-cluster-scoped/values.yaml
@@ -3,6 +3,8 @@
 cpfs:
   imageRegistryNamespaceOperator: cpopen
   imageRegistryNamespaceOperand: cpopen/cpfs
+  labels:
+  clusterLabels:
 
 global:
   operatorNamespace: operators


### PR DESCRIPTION
What this PR does / why we need it: CPD BR team requires cluster scoped resources to have both addOnID and tenant operator namespace defined in all cluster resources so they can be appropriately tracked and backed up. Enabling these values allows for flexibly setting both common labels for namespace scoped and cluster scoped resources and cluster specific labels.

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/57014