### PR TITLE
make labeling conditional

### DIFF
--- a/helm-cluster-scoped/templates/00-crd.yaml
+++ b/helm-cluster-scoped/templates/00-crd.yaml
@@ -7,12 +7,16 @@ metadata:
   name: namespacescopes.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
-    {{- with .Values.cpfs.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.cpfs.clusterLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- if .Values.cpfs.labels }}
+      {{- with .Values.cpfs.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
+    {{- if .Values.cpfs.clusterLabels }}
+      {{- with .Values.cpfs.clusterLabels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/01-cluster-rbac.yaml
+++ b/helm-cluster-scoped/templates/01-cluster-rbac.yaml
@@ -4,12 +4,16 @@ metadata:
   name: ibm-namespace-scope-operator-{{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
-    {{- with .Values.cpfs.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
-    {{- with .Values.cpfs.clusterLabels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- if .Values.cpfs.labels }}
+      {{- with .Values.cpfs.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
+    {{- if .Values.cpfs.clusterLabels }}
+      {{- with .Values.cpfs.clusterLabels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
 rules:
   - verbs:
       - create
@@ -38,6 +42,16 @@ metadata:
   name: ibm-namespace-scope-operator-{{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
+    {{- if .Values.cpfs.labels }}
+      {{- with .Values.cpfs.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
+    {{- if .Values.cpfs.clusterLabels }}
+      {{- with .Values.cpfs.clusterLabels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
 subjects:
   - kind: ServiceAccount
     name: ibm-namespace-scope-operator

--- a/helm/templates/00-rbac.yaml
+++ b/helm/templates/00-rbac.yaml
@@ -6,7 +6,9 @@
 {{- if .Values.global.instanceNamespace }}
   {{- $namespaces = append $namespaces .Values.global.instanceNamespace }}
 {{- end }}
-{{- $labels := .Values.cpfs.labels }}
+{{- if .Values.cpfs.labels }}
+  {{- $labels := .Values.cpfs.labels }}
+{{- end }}
 {{- range $i := $namespaces }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,8 +17,10 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName }}
-    {{- with $labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if .Values.cpfs.labels }}
+      {{- with $labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
     {{- end }}
 rules:
   - verbs:
@@ -98,8 +102,10 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName }}
-    {{- with $labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if .Values.cpfs.labels }}
+      {{- with $labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
     {{- end }}
 subjects:
   - kind: ServiceAccount
@@ -119,8 +125,10 @@ metadata:
     app.kubernetes.io/managed-by: ibm-namespace-scope-operator
     app.kubernetes.io/name: ibm-namespace-scope-operator
     component-id: {{ .Chart.Name }}
-    {{- with .Values.cpfs.labels }}
-      {{- toYaml . | nindent 4 }}
+    {{- if .Values.cpfs.labels }}
+      {{- with $labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
     {{- end }}
   name: ibm-namespace-scope-operator
   namespace: {{ .Values.global.operatorNamespace }}

--- a/helm/templates/01-operator-deployment.yaml
+++ b/helm/templates/01-operator-deployment.yaml
@@ -9,9 +9,11 @@ metadata:
     app.kubernetes.io/name: ibm-namespace-scope-operator
     productName: IBM_Cloud_Platform_Common_Services
     component-id: {{ .Chart.Name }}
-    {{- with .Values.cpfs.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- if .Values.cpfs.labels }}
+      {{- with .Values.cpfs.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
 spec:
   replicas: 1
   selector:

--- a/helm/templates/02-nss-cr.yaml
+++ b/helm/templates/02-nss-cr.yaml
@@ -5,9 +5,11 @@ metadata:
     cpfs.helm/install: 'true'
     foundationservices.cloudpak.ibm.com: nss
     component-id: {{ .Chart.Name }}
-    {{- with .Values.cpfs.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- if .Values.cpfs.labels }}
+      {{- with .Values.cpfs.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end}}
   name: common-service
   namespace: {{ .Values.global.operatorNamespace }}
 spec:


### PR DESCRIPTION
See https://github.com/IBM/ibm-common-service-operator/pull/2636

essentially, the CPD team has trouble with the helm charts when the labels fields are not defined so making them conditional should side step this problem