### PR TITLE
Enable detect secrets for release-sc2

### DIFF
--- a/.pipeline-config-ci.yaml
+++ b/.pipeline-config-ci.yaml
@@ -10,7 +10,7 @@ tasks:
       - name: checks-setup
         when: 'false'
       - name: detect-secrets
-        when: 'false'
+        when: 'true'
         include:
           - docker-socket
       - name: compliance-checks

--- a/.pipeline-config-pr.yaml
+++ b/.pipeline-config-pr.yaml
@@ -10,7 +10,7 @@ tasks:
       - name: checks-setup
         when: 'false'
       - name: detect-secrets
-        when: 'false'
+        when: 'true'
         include:
           - docker-socket
       - name: unit-test
@@ -42,7 +42,7 @@ tasks:
       - name: checks-setup
         when: 'false'
       - name: detect-secrets
-        when: 'false'
+        when: 'true'
         include:
           - docker-socket
       - name: unit-test
@@ -74,7 +74,7 @@ tasks:
       - name: checks-setup
         when: 'false'
       - name: detect-secrets
-        when: 'false'
+        when: 'true'
         include:
           - docker-socket
       - name: unit-test
@@ -103,7 +103,7 @@ tasks:
       - name: compliance-checks
         when: 'false'
 
-  pr-code-checks-ppc:
+  pr-code-checks-ppc64le:
     from: pr-code-checks
     runtimeClassName: x86-xlarge
     include:
@@ -180,7 +180,7 @@ tasks:
     runtimeClassName: x86-xlarge
     runAfter: 
       - pr-code-checks-amd64
-      - pr-code-checks-ppc
+      - pr-code-checks-ppc64le
       - pr-code-checks-s390
     include:
       - dind
@@ -188,7 +188,7 @@ tasks:
       - name: checks-setup
         when: 'false'
       - name: detect-secrets
-        when: 'false'
+        when: 'true'
         include:
           - docker-socket
           - dind

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|go.mod|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-11-03T14:16:38Z",
+  "generated_at": "2025-11-10T14:11:13Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -94,26 +94,6 @@
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null
-      }
-    ],
-    "helm-cluster-scoped/values.yaml": [
-      {
-        "hashed_secret": "da5743b16ccee188d5e5c28cea321ce7a041f4cb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 2,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "helm/values.yaml": [
-      {
-        "hashed_secret": "da5743b16ccee188d5e5c28cea321ce7a041f4cb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 5,
-        "type": "Secret Keyword",
         "verified_result": null
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,126 @@
+{
+  "exclude": {
+    "files": "go.sum|go.mod|^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2025-11-03T14:16:38Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "common/Makefile.common.mk": [
+      {
+        "hashed_secret": "1c9b29b40c7759ef4666dff4065908278fa4c837",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "config/manager/manager.yaml": [
+      {
+        "hashed_secret": "b9274fd20e965ade322fd1b50fff623eabaa1c3b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "helm-cluster-scoped/values.yaml": [
+      {
+        "hashed_secret": "da5743b16ccee188d5e5c28cea321ce7a041f4cb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "helm/values.yaml": [
+      {
+        "hashed_secret": "da5743b16ccee188d5e5c28cea321ce7a041f4cb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.64.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ e2e-test: ## Run e2e test
 prepare-buildx:
 	@docker buildx inspect $(BUILDX_BUILDER) >/dev/null 2>&1 || docker buildx create --name $(BUILDX_BUILDER) --driver docker-container --use
 	@docker buildx use $(BUILDX_BUILDER)
-	@docker run --privileged --rm tonistiigi/binfmt --install all >/dev/null
 
 build-operator-image: config-docker prepare-buildx ## Build the operator image.
 	@echo "Building the $(OPERATOR_IMAGE_NAME) docker image for $(LOCAL_ARCH)..."


### PR DESCRIPTION
What this PR does / why we need it:
enable and add .secrets.baseline file for secret detection configuration

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68163