### PR TITLE
uplift go version to 1.25.7 for security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-dockerhub-docker-remote/golang:1.25.5 AS builder
+FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-dockerhub-docker-remote/golang:1.25.7 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GOARCH

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/IBM/ibm-namespace-scope-operator/v4
 
-go 1.23.0
-
-toolchain go1.23.4
+go 1.25.7
 
 require (
 	github.com/deckarep/golang-set v1.7.1


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68782