### PR TITLE
Reduce apps RBAC to minimum required permissions

### DIFF
--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -209,17 +209,17 @@ spec:
                 - apps
               resources:
                 - deployments
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - apps
+              resources:
                 - daemonsets
                 - statefulsets
               verbs:
-                - delete
                 - get
-                - list
                 - patch
-                - update
-                - watch
-                - deletecollection
-                - create
             - apiGroups:
                 - ""
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -53,18 +53,18 @@ rules:
       - namespacescopes/status
       - namespacescopes/finalizers
   - verbs:
-      - delete
       - get
-      - list
-      - patch
       - update
-      - watch
-      - deletecollection
-      - create
     apiGroups:
       - apps
     resources:
       - deployments
+  - verbs:
+      - get
+      - patch
+    apiGroups:
+      - apps
+    resources:
       - daemonsets
       - statefulsets
   - verbs:

--- a/helm/templates/00-rbac.yaml
+++ b/helm/templates/00-rbac.yaml
@@ -71,18 +71,18 @@ rules:
       - namespacescopes/status
       - namespacescopes/finalizers
   - verbs:
-      - delete
       - get
-      - list
-      - patch
       - update
-      - watch
-      - deletecollection
-      - create
     apiGroups:
       - apps
     resources:
       - deployments
+  - verbs:
+      - get
+      - patch
+    apiGroups:
+      - apps
+    resources:
       - daemonsets
       - statefulsets
   - verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Split `deployments` RBAC from `daemonsets/statefulsets`
- Keep only the verbs required by the controller logic:
  ```
  deployments: get, update
  daemonsets, statefulsets: get, patch
  ```
- Updated all related RBAC definitions in Role and CSV

**Which issue(s) this PR fixes**:
Fixes # [ttps://github.ibm.com/IBMPrivateCloud/roadmap/issues/68833](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68833)