### PR TITLE
Add liveness/readiness probes to operator deployment manifests 

### DIFF
--- a/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-namespace-scope-operator.clusterserviceversion.yaml
@@ -142,6 +142,29 @@ spec:
                         cpu: 100m
                         ephemeral-storage: 256Mi
                         memory: 200Mi
+                    ports:
+                      - containerPort: 8080
+                        name: metrics
+                        protocol: TCP
+                      - containerPort: 8081
+                        name: health
+                        protocol: TCP
+                    livenessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 120
+                      periodSeconds: 60
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 20
+                      timeoutSeconds: 20
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,22 @@ spec:
             cpu: 100m
             memory: 200Mi
             ephemeral-storage: 256Mi
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
         securityContext:
           seccompProfile:
             type: RuntimeDefault

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,18 +69,25 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
-          initialDelaySeconds: 15
-          periodSeconds: 20
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 60
+          failureThreshold: 10
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
+            path: /readyz
+            port: 8081
           initialDelaySeconds: 5
-          periodSeconds: 10
+          timeoutSeconds: 20
+          periodSeconds: 20
+          failureThreshold: 10
         securityContext:
           seccompProfile:
             type: RuntimeDefault

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,16 +36,23 @@ spec:
         - containerPort: 8080
           name: metrics
           protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
-          initialDelaySeconds: 15
-          periodSeconds: 20
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 60
+          failureThreshold: 10
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
+            path: /readyz
+            port: 8081
           initialDelaySeconds: 5
-          periodSeconds: 10
+          timeoutSeconds: 20
+          periodSeconds: 20
+          failureThreshold: 10
       terminationGracePeriodSeconds: 10

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,4 +31,21 @@ spec:
         - --enable-leader-election=false
         image: quay.io/opencloudio/ibm-namespace-scope-operator:latest
         name: manager
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
       terminationGracePeriodSeconds: 10

--- a/helm/templates/01-operator-deployment.yaml
+++ b/helm/templates/01-operator-deployment.yaml
@@ -111,6 +111,22 @@ spec:
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: File
           image: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperator }}/ibm-namespace-scope-operator:4.3.5
+          ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
       serviceAccount: ibm-namespace-scope-operator
       dnsPolicy: ClusterFirst
   strategy:

--- a/helm/templates/01-operator-deployment.yaml
+++ b/helm/templates/01-operator-deployment.yaml
@@ -115,18 +115,25 @@ spec:
           - containerPort: 8080
             name: metrics
             protocol: TCP
+          - containerPort: 8081
+            name: health
+            protocol: TCP
           livenessProbe:
             httpGet:
-              path: /metrics
-              port: 8080
-            initialDelaySeconds: 15
-            periodSeconds: 20
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 60
+            failureThreshold: 10
           readinessProbe:
             httpGet:
-              path: /metrics
-              port: 8080
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 5
-            periodSeconds: 10
+            timeoutSeconds: 20
+            periodSeconds: 20
+            failureThreshold: 10  
       serviceAccount: ibm-namespace-scope-operator
       dnsPolicy: ClusterFirst
   strategy:

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
@@ -54,17 +55,20 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true))) // Use zap logger
 
 	var metricsAddr string
+	var probeAddr string
 	var enableLeaderElection bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-addr", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
 	options := ctrl.Options{
-		Scheme:           scheme,
-		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: "6a4a72f9.ibm.com",
+		Scheme:                 scheme,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "6a4a72f9.ibm.com",
 	}
 
 	operatorNs, err := common.GetOperatorNamespace()
@@ -91,6 +95,15 @@ func main() {
 		os.Exit(1)
 	}
 	// +kubebuilder:scaffold:builder
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		klog.Errorf("unable to set up health check: %v", err)
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		klog.Errorf("unable to set up ready check: %v", err)
+		os.Exit(1)
+	}
 
 	klog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
**Summary:** Add HTTP liveness and readiness probes to the operator container to meet Kyverno policies requirement.

**Issue:**  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68808/#issuecomment-181904012

**What changed:**

- Added ports 
- Added livenessProbe 
- Added readinessProbe
- Added ProbeBindAddr