### PR TITLE
Add AGENTS.md and internal wiki for AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Rules
+
+## Start with the wiki
+
+At the start of each task, check `_context/wiki/index.md` to decide
+whether wiki context is needed before acting. Don't read the wiki in
+full. Use the index and follow links only when they are relevant to
+the task.
+
+## Update the wiki
+
+After completing a task, offer to update the wiki if the task yielded durable knowledge that could benefit future work, then wait for user approval. This includes new processes, architecture decisions, or insights that go beyond the immediate task.

--- a/_context/wiki/index.md
+++ b/_context/wiki/index.md
@@ -1,0 +1,18 @@
+# ibm-namespace-scope-operator Wiki
+
+Operator that extends RBAC permissions of CPfs (and Cloud Pak) operators to additional namespaces. Only required when CPfs is installed in OwnNamespace mode with multi-namespace operand management.
+
+## Contents
+
+| File | What's in it |
+|------|-------------|
+| [project.md](project.md) | Project overview, goals, automatic vs manual mode, installation conditions |
+| [preferences.md](preferences.md) | Working standards, coding style, AI collaboration preferences |
+
+## Quick orientation
+
+- Only installed when CPfs runs in **OwnNamespace mode** and needs to manage operands across multiple namespaces.
+- Extends RBAC by copying Roles from opted-in operators and binding them to their ServiceAccounts in target namespaces.
+- **Two modes:** automatic (default — extends RBAC automatically) and manual (user must explicitly authorize).
+- Manages the `NamespaceScope` CRD.
+- Most work is **bug fixes**.

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -1,0 +1,26 @@
+# Working Preferences & Standards
+
+## How I use AI
+
+- **Bug fixes** — the most common use case. Understand the problem before suggesting a fix.
+- **Understanding RBAC behaviour** — tracing why permissions are or aren't being propagated in automatic vs. manual mode.
+- **Understanding unfamiliar code** — orientation to areas not recently touched.
+
+## Communication preferences
+
+- Be direct and technical. No filler phrases ("Great!", "Certainly!", etc.).
+- Investigate before answering — never speculate about code you haven't read.
+- When explaining unfamiliar code: start with what it *does*, then how it works.
+- Flag assumptions explicitly.
+
+## Code style & engineering standards
+
+- **Minimal changes.** Produce the smallest diff that solves the problem. No opportunistic refactors.
+- **Trace every changed line** back to the stated requirement.
+- **Go conventions.** Follow standard Go idioms and the existing style in the file being edited.
+
+## What to be careful about
+
+- **Automatic vs. manual mode.** Always clarify which mode is active before debugging RBAC propagation issues — behaviour is completely different between the two.
+- **Installation conditions.** This operator is only relevant in OwnNamespace + multi-namespace scenarios. Changes should not assume AllNamespace context.
+- **RBAC copying is additive but not always reversible.** Be careful with changes that affect how Roles are cleaned up when a namespace is removed from scope.

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -1,0 +1,46 @@
+# Project Overview
+
+## What this project is
+
+`ibm-namespace-scope-operator` extends RBAC permissions of CPfs and Cloud Pak operators to namespaces outside their own. It is only installed when CPfs runs in **OwnNamespace mode** and operators need to manage operands across multiple namespaces.
+
+It works by copying Roles from opted-in operators and binding them to those operators' ServiceAccounts in the target namespaces, effectively granting cross-namespace permissions without requiring AllNamespace mode.
+
+## Main goals
+
+1. **Cross-namespace RBAC extension** — allow OwnNamespace-mode operators to act in additional namespaces.
+2. **Support OwnNamespace CPfs deployments** — prerequisite only when this combination of conditions applies.
+3. **Bug fixes** — primary ongoing work.
+
+## Key stakeholders / users
+
+- **CPfs platform team** — maintainers.
+- **IBM Cloud Pak teams** — consume this when deploying CPfs or their own operators in OwnNamespace mode with multi-namespace operand management.
+- **End customers** — indirectly, through Cloud Pak installations.
+
+## Installation conditions
+
+This operator is only needed when **all** of the following are true:
+1. CPfs (or a Cloud Pak) is installed in **OwnNamespace mode**
+2. The operator needs to manage operands in **multiple namespaces**
+
+If CPfs is installed in AllNamespace mode, this operator is not used.
+
+## Key CRDs
+
+| CRD | Purpose |
+|-----|---------|
+| `NamespaceScope` | Defines which operators are opted in and which namespaces they should receive extended RBAC for |
+
+## Operating modes
+
+| Mode | Behaviour |
+|------|-----------|
+| **Automatic** (default) | Operator extends RBAC to target namespaces automatically for opted-in operators |
+| **Manual** | A user must explicitly authorize the operator before it will copy RBAC to target namespaces |
+
+The automatic vs. manual distinction is a common source of support issues — always clarify which mode is active when debugging RBAC-related problems.
+
+## Key workflows
+
+- **Bug fixes** — most common work.


### PR DESCRIPTION
Adds AGENTS.md agent rules file and internal wiki under _context/wiki/ to support AI-assisted development.